### PR TITLE
fix: rum agent to be symlinked before npm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ build
 .DS_Store
 .env
 npm-debug.log
+
+# master branch of rum agent
+elastic-apm-rum
+
+#lockfiles
+yarn.lock
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "css-loader": "^1.0.1",
     "detect-port": "1.0.1",
     "dotenv": "2.0.0",
-    "elastic-apm-js-base": "git+https://git@github.com/elastic/apm-agent-js-base.git",
+    "elastic-apm-rum": "file:elastic-apm-rum",
     "eslint": "^5.8.0",
     "eslint-config-react-app": "^0.5.0",
     "eslint-loader": "^2.1.1",
@@ -59,6 +59,7 @@
     "whatwg-fetch": "1.0.0"
   },
   "scripts": {
+    "preinstall": "if ! [ -d elastic-apm-rum ]; then git clone --single-branch --branch test-opbeans git@github.com:vigneshshanmugam/apm-agent-js-base.git elastic-apm-rum; fi",
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "whatwg-fetch": "1.0.0"
   },
   "scripts": {
-    "preinstall": "if ! [ -d elastic-apm-rum ]; then git clone --single-branch --branch test-opbeans git@github.com:vigneshshanmugam/apm-agent-js-base.git elastic-apm-rum; fi",
+    "preinstall": "if ! [ -d elastic-apm-rum ]; then git clone https://github.com/elastic/apm-agent-js-base elastic-apm-rum; fi",
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom"

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,19 +1,16 @@
 import React from 'react';
 import { Router, Route, IndexRedirect } from 'react-router';
+import { apm } from 'elastic-apm-js-base/src/index'
+
 import App from './components/App';
-
 import Dashboard from './components/Dashboard';
-
 import Product from './components/Product';
 import Products from './components/Products';
 import Orders from './components/Orders';
 import Order from './components/Order';
 import Customers from './components/Customers';
 import Customer from './components/Customer';
-
 import NotFound from './components/NotFound';
-
-var apm = require('elastic-apm-js-base/src/index').apm
 
 const Routes = (props) => (
   <Router {...props}>

--- a/src/rum.js
+++ b/src/rum.js
@@ -1,6 +1,7 @@
 
 import { init as initApm } from 'elastic-apm-js-base/src/index'
 import { browserHistory } from 'react-router'
+import { patching } from 'elastic-apm-js-core'
 
 function changeRoute() {
     var links = Array.from(document.getElementsByTagName('a')).map((a) => {
@@ -55,7 +56,7 @@ rumConfig.logLevel = 'debug'
 
 var apm = initApm(rumConfig)
 
-var sub = require('elastic-apm-js-core').patching.subscription
+var sub = patching.subscription
 sub.subscribe(function (event, task) {
     var tr = apm.getCurrentTransaction()
     if (tr && event === 'schedule' && task.type === 'macroTask' && !task.id) {


### PR DESCRIPTION
+ PR relies on a custom branch of my fork, Once its merged to https://github.com/elastic/apm-agent-js-base, I will change it to point to master.
+ npm install with git urls wont work properly for mono repos, so this was a simplest solution that can work with both npm and yarn. Other solutions either relies on yarn linking or lerna which required lots of changes and would stick us with one of the package managers. 

Link to npm issue - https://github.com/npm/npm/issues/18266