### PR TITLE
fix: build docker image issue-9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ ENV NODE_ENV=production
 ENV ELASTIC_APM_JS_BASE_SERVICE_NAME=opbeans-react
 
 WORKDIR /app
-ADD . /app
+COPY . /app
 
-RUN npm install && npm run-script build && rm -rf node_modules
+RUN yarn install \
+    && npm run-script build \
+    && rm -rf node_modules
 CMD ["npm", "run-script", "start"]


### PR DESCRIPTION
Fix Docker image build without a previous `npm install`

see https://github.com/elastic/opbeans-frontend/issues/9