### PR TITLE
lighter docker image for the obpeans-frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:12-alpine
 
+RUN apk update && \
+    apk --no-cache add git && \
+    rm -rf /var/cache/apk/*
+
 ENV NODE_ENV=production
 ENV ELASTIC_APM_JS_BASE_SERVICE_NAME=opbeans-react
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:12-alpine
 
 ENV NODE_ENV=production
 ENV ELASTIC_APM_JS_BASE_SERVICE_NAME=opbeans-react


### PR DESCRIPTION
## Highlights
- Docker image size from `1.7gb` to `950mb`
- Git is required to be installed as the alpine doesn't have it by default.