### PR TITLE
fix: remove RUM agent node_modules to resolve packages correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "scripts": {
     "preinstall": "if ! [ -d elastic-apm-rum ]; then git clone --branch='master' https://github.com/elastic/apm-agent-rum-js elastic-apm-rum --depth 1; fi",
-    "postinstall": "npm install --prefix ./elastic-apm-rum --dev --prod && npx lerna run build --stream",
+    "postinstall": "npm install --prefix ./elastic-apm-rum --dev --prod && npx lerna run build --stream && rm -rf ./elastic-apm-rum/node_modules",
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom"


### PR DESCRIPTION
+ fix #30 
+ We need the dev and prod deps only for building the `RUM` agent. So removing it after the postinstall script fixes the problem of resolving the  packages locally and instead resolves packages referenced from RUM agent to the top level opbeans `node_modules`