### PR TITLE
fixes: master branch is not there anymore

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 AGENT_VERSION="${1?Missing the APM rum agent version}"
 
 # Bump version
-sed -ibck "s#--branch='master'#--branch='${AGENT_VERSION}'#g" package.json
+sed -ibck "s#--branch='.*' #--branch='${AGENT_VERSION}' #g" package.json
 
 # Commit changes
 git add package.json


### PR DESCRIPTION
Bump the latest release instead the master branch, that only happens the very first time though

Otherwise:
- https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-rum%2Fapm-agent-rum-mbp/detail/%40elastic%2Fapm-rum%404.7.1/1/pipeline#step-1453-log-3