### PR TITLE
Enable to use sha versions in addition to tags/branches

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 AGENT_VERSION="${1?Missing the APM rum agent version}"
 
 # Bump version
-sed -ibck "s#--branch='.*' #--branch='${AGENT_VERSION}' #g" package.json
+sed -ibck "s#git fetch origin '.*';#git fetch origin '${AGENT_VERSION}';#g" package.json
 
 # Commit changes
 git add package.json

--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -2,10 +2,13 @@
 set -euxo pipefail
 
 AGENT_VERSION="${1?Missing the APM rum agent version}"
+IS_COMMIT="${2:-true}"
 
 # Bump version
 sed -ibck "s#git fetch origin '.*';#git fetch origin '${AGENT_VERSION}';#g" package.json
 
 # Commit changes
-git add package.json
-git commit -m "Bump version ${AGENT_VERSION}"
+if [ "${IS_COMMIT}" == "true" ] ; then
+    git add package.json
+    git commit -m "Bump version ${AGENT_VERSION}"
+fi

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "whatwg-fetch": "1.0.0"
   },
   "scripts": {
-    "preinstall": "if ! [ -d elastic-apm-rum ]; then git clone --branch='@elastic/apm-rum@4.8.1' https://github.com/elastic/apm-agent-rum-js elastic-apm-rum --depth 1; fi",
+    "preinstall": "if ! [ -d elastic-apm-rum ]; then (git clone https://github.com/elastic/apm-agent-rum-js elastic-apm-rum --depth 1; cd elastic-apm-rum; git fetch origin '@elastic/apm-rum@4.8.1'; git reset --hard FETCH_HEAD) fi",
     "postinstall": "npm install --prefix ./elastic-apm-rum --dev --prod && npx lerna run build --stream && rm -rf ./elastic-apm-rum/node_modules",
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",


### PR DESCRIPTION
## What

- `git clone --branch` does only support braches/tags but no sha.
- Enable flag to disable the git add/commit afterward.

Implementation details based on some of the suggestions in [here](https://stackoverflow.com/a/3489576)

## Why

It will allow us to validate if the PRs in the apm-agent-rum-js do work with this project as expected.

## Related issues

Caused by https://github.com/elastic/apm-integration-testing/pull/763