### PR TITLE
skip download of chromium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk update && \
 
 ENV NODE_ENV=production
 ENV ELASTIC_APM_JS_BASE_SERVICE_NAME=opbeans-react
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
IIUC, chromium might not be required when building the opbeans docker image as it does only use the agent bundlers.

See [env variables](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#environment-variables)

### Issue

Closes https://github.com/elastic/apm-integration-testing/issues/844