### PR TITLE
docker: add labels metadata

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -7,8 +7,11 @@ IS_COMMIT="${2:-true}"
 # Bump version
 sed -ibck "s#git fetch origin '.*';#git fetch origin '${AGENT_VERSION}';#g" package.json
 
+## Bump agent version in the Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
+
 # Commit changes
 if [ "${IS_COMMIT}" == "true" ] ; then
-    git add package.json
+    git add package.json Dockerfile
     git commit -m "Bump version ${AGENT_VERSION}"
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,13 @@ COPY . /app
 RUN npm install --unsafe-perm \
     && npm run-script build
 
+LABEL \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.vendor="Elastic" \
+    org.label-schema.name="opbeans-frontend" \
+    org.label-schema.version="5.2.1" \
+    org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-frontend" \
+    org.label-schema.vcs-url="https://github.com/elastic/opbeans-frontend" \
+    org.label-schema.license="MIT"
+
 CMD ["npm", "run-script", "start"]


### PR DESCRIPTION
Added some labels to easily identify what's the agent version that the opbeans is consuming, in addition to some labels that are generated for some other Elastic docker images.

### Tests

```bash
IMAGE=docker.elastic.co/observability-ci/opbeans-frontend:81b7ed055b2ab5df827b3f4b7f5d0b116803101e
$ docker pull ${IMAGE}
$ docker inspect ${IMAGE} | jq -r '.[0].Config.Labels'
{
  "org.label-schema.license": "MIT",
  "org.label-schema.name": "opbeans-frontend",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "https://hub.docker.com/r/opbeans/opbeans-frontend",
  "org.label-schema.vcs-url": "https://github.com/elastic/opbeans-frontend",
  "org.label-schema.vendor": "Elastic",
  "org.label-schema.version": "5.2.1"
}
```