### PR TITLE
fix: script to support multiline script

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -8,7 +8,7 @@ IS_COMMIT="${2:-true}"
 sed -ibck "s#git fetch origin '.*';#git fetch origin '${AGENT_VERSION}';#g" package.json
 
 ## Bump agent version in the Dockerfile
-sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(\".*\"\)\(.*\)#\1\"${AGENT_VERSION}\"\3#g" Dockerfile
 
 # Commit changes
 if [ "${IS_COMMIT}" == "true" ] ; then


### PR DESCRIPTION
Fixes an issue with the sed transformation

from

```diff
index c83acb8..bafb7d6 100755
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Elastic" \
     org.label-schema.name="opbeans-frontend" \
-    org.label-schema.version="5.2.1" \
+    org.label-schema.version="5.8.0" 
     org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-frontend" \
     org.label-schema.vcs-url="https://github.com/elastic/opbeans-frontend" \
     org.label-schema.license="MIT"
````


to:

```diff
index c83acb8..bafb7d6 100755
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Elastic" \
     org.label-schema.name="opbeans-frontend" \
-    org.label-schema.version="5.2.1" \
+    org.label-schema.version="5.8.0" \
     org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-frontend" \
     org.label-schema.vcs-url="https://github.com/elastic/opbeans-frontend" \
     org.label-schema.license="MIT"
```