### PR TITLE
docs: build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-agent-nodejs%2Fopbeans-frontend-mbp%2Fmaster)](https://apm-ci.elastic.co/job/apm-agent-nodejs/job/opbeans-frontend-mbp/job/master/)
+[![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-agent-rum%2Fopbeans-frontend-mbp%2Fmaster)](https://apm-ci.elastic.co/job/apm-agent-rum/job/opbeans-frontend-mbp/job/master/)
 
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
 


### PR DESCRIPTION
Job was moved from apm-agent-nodejs but it was not changed the build badge reference