### PR TITLE
[opbeans-php] Enable dependent opbeans-php

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -5,5 +5,6 @@ opbeansPipeline(downstreamJobs: ['apm-agent-dotnet/opbeans-dotnet-mbp/master',
                                  'apm-agent-go/opbeans-go-mbp/master',
                                  'apm-agent-java/opbeans-java-mbp/master',
                                  'apm-agent-nodejs/opbeans-node-mbp/master',
+                                 'apm-agent-python/opbeans-php-mbp/master'
                                  'apm-agent-python/opbeans-python-mbp/master',
                                  'apm-agent-ruby/opbeans-ruby-mbp/master'])

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -5,6 +5,6 @@ opbeansPipeline(downstreamJobs: ['apm-agent-dotnet/opbeans-dotnet-mbp/master',
                                  'apm-agent-go/opbeans-go-mbp/master',
                                  'apm-agent-java/opbeans-java-mbp/master',
                                  'apm-agent-nodejs/opbeans-node-mbp/master',
-                                 'apm-agent-python/opbeans-php-mbp/master'
+                                 'apm-agent-php/opbeans-php-mbp/master',
                                  'apm-agent-python/opbeans-python-mbp/master',
                                  'apm-agent-ruby/opbeans-ruby-mbp/master'])


### PR DESCRIPTION
If the opbeans-php requires the frontend then let's add this to be built

### Issues

Caused by https://github.com/elastic/opbeans-php/issues/1