### PR TITLE
fix: lint warnings so 'CI=true npm run build' passes

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { useParams,Route, Navigate, Routes } from 'react-router-dom'
-import { withTransaction } from '@elastic/apm-rum-react'
 
 import AppHeader from '../AppHeader';
 import AppFooter from '../AppFooter';
@@ -55,7 +54,7 @@ class App extends Component {
           <Route path="/products" element={<Products />} />
           <Route path="/products/:id" element={<ProductId />} />
           <Route path="/orders" element={<Orders />} />
-          <Route path="/orders/:id" element={<OrderId />} /> 
+          <Route path="/orders/:id" element={<OrderId />} />
           <Route path="/customers" element={ <Customers />} />
           <Route path="/customers/:id" element={<CustomerId />} />
           <Route element={NotFound} />

--- a/src/components/AppFooter/index.js
+++ b/src/components/AppFooter/index.js
@@ -21,7 +21,9 @@ class AppFooter extends Component {
                               <NavLink className="item" style={({ isActive }) => isActive ? {textDecoration: "underline"} : undefined} to="/dashboard">
                                   Dashboard
                               </NavLink>
+                              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                               <a href="#" onClick={ this.getSettingsWindow } className="item">Settings</a>
+                              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                               <a href="#" className="item disabled">Log out</a>
                           </div>
                       </div>

--- a/src/reducers/initialState.js
+++ b/src/reducers/initialState.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-anonymous-default-export
 export default {
   product: { loading: true, product: {} },
   productCustomers: { loading: false, items: [] },


### PR DESCRIPTION
Fixes: #119

----

This just fixes or ignores the lint warnings. Actual changes to fix the warnings are welcome.
Also it would be nice to have *this* repo's CI fail if there are lint warnings, given that if there are it breaks the downstream opbeans-node. However, I haven't dug into doing that.