### PR TITLE
deps: use node20 and npm 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 RUN apk update && \
     apk --no-cache add git && \
@@ -8,7 +8,7 @@ ENV NODE_ENV=production
 ENV ELASTIC_APM_JS_BASE_SERVICE_NAME=opbeans-react
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
-RUN npm install npm@latest -g 
+RUN npm install npm@v11.0.0 -g
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
npm 11 stopped support for node18

See https://github.com/npm/cli/releases/tag/v11.0.0

> npm now supports node ^20.17.0 || >=22.9.0

Therefore, the CI stopped working. See https://github.com/elastic/opbeans-frontend/actions/runs/12727194854/job/35476446434?pr=221

```
> [3/7] RUN npm install npm@latest -g:
0.783 npm error code EBADENGINE
0.783 npm error engine Unsupported engine
0.783 npm error engine Not compatible with your version of node/npm: npm@11.0.0
0.783 npm error notsup Not compatible with your version of node/npm: npm@11.0.0
0.783 npm error notsup Required: {"node":"^20.17.0 || >=22.9.0"}
0.783 npm error notsup Actual:   {"npm":"10.8.2","node":"v18.20.5"}
0.7[86](https://github.com/elastic/opbeans-frontend/actions/runs/12727194854/job/35476446434?pr=221#step:3:87) npm error A complete log of this run can be found in: /root/.npm/_logs/2025-01-11T20_03_25_637Z-debug-0.log
------
Dockerfile:11
```