### PR TITLE
Add cooldown to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
+    cooldown:
+      days: 14
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
Added cooldown period of 14 days for Dependabot updates.